### PR TITLE
Improve handling of the environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 examples/
 caddy
 deps.go
+*.porig
+*.orig
+*.rej

--- a/adapt.go
+++ b/adapt.go
@@ -1,23 +1,32 @@
 package caddyyaml
 
 import (
+	"errors"
+
 	"github.com/caddyserver/caddy/v2/caddyconfig"
 )
 
 func adapt(body []byte, options map[string]interface{}) ([]byte, []caddyconfig.Warning, error) {
+	filename, ok := options["filename"].(string)
+	if !ok {
+		return nil, nil, errors.New("missing filename option")
+	}
+
+	wc := newWarningsCollector(filename)
+
 	// extract variables
 	vars, err := varsFromBody(body)
 	if err != nil {
-		return nil, nil, err
+		return nil, wc.warnings, err
 	}
 
 	// apply template
 	tmp, err := applyTemplate(body, vars)
 	if err != nil {
-		return nil, nil, err
+		return nil, wc.warnings, err
 	}
 
 	// convert to YAML
 	result, err := yamlToJSON(tmp)
-	return result, nil, err
+	return result, wc.warnings, err
 }

--- a/adapt.go
+++ b/adapt.go
@@ -27,7 +27,7 @@ func adapt(body []byte, options map[string]interface{}) ([]byte, []caddyconfig.W
 	}
 
 	// apply template
-	tmp, err := applyTemplate(body, vars, env)
+	tmp, err := applyTemplate(body, vars, env, wc)
 	if err != nil {
 		return nil, wc.warnings, err
 	}

--- a/adapt.go
+++ b/adapt.go
@@ -2,6 +2,7 @@ package caddyyaml
 
 import (
 	"errors"
+	"os"
 
 	"github.com/caddyserver/caddy/v2/caddyconfig"
 )
@@ -12,16 +13,21 @@ func adapt(body []byte, options map[string]interface{}) ([]byte, []caddyconfig.W
 		return nil, nil, errors.New("missing filename option")
 	}
 
+	env, ok := options[envOptionName].([]string)
+	if !ok {
+		env = os.Environ()
+	}
+
 	wc := newWarningsCollector(filename)
 
 	// extract variables
-	vars, err := varsFromBody(body)
+	vars, err := varsFromBody(body, env)
 	if err != nil {
 		return nil, wc.warnings, err
 	}
 
 	// apply template
-	tmp, err := applyTemplate(body, vars)
+	tmp, err := applyTemplate(body, vars, env)
 	if err != nil {
 		return nil, wc.warnings, err
 	}

--- a/adapt_test.go
+++ b/adapt_test.go
@@ -3,30 +3,37 @@ package caddyyaml
 import (
 	"encoding/json"
 	"io/ioutil"
-	"os"
 	"reflect"
 	"testing"
 )
 
 func TestApply(t *testing.T) {
 	tests := []struct {
-		filename    string
-		environment string
+		name     string
+		filename string
+		env      []string
 	}{
-		{filename: "test.caddy.json"},
-		{filename: "test.caddy.prod.json", environment: "production"},
+		{
+			name:     "simple",
+			filename: "test.caddy.json",
+			env:      []string{"ENVIRONMENT=something"},
+		},
+		{
+			name:     "production environment",
+			filename: "test.caddy.prod.json",
+			env:      []string{"ENVIRONMENT=production"},
+		},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.environment, func(t *testing.T) {
-			os.Setenv("ENVIRONMENT", tt.environment)
-
+		t.Run(tt.name, func(t *testing.T) {
 			b, err := ioutil.ReadFile("./testdata/test.caddy.yaml")
 			if err != nil {
 				t.Fatal(err)
 			}
 			adaptedBytes, _, err := Adapter{}.Adapt(b, map[string]interface{}{
-				"filename": "test.caddy.yaml",
+				"filename":    "test.caddy.yaml",
+				envOptionName: tt.env,
 			})
 			if err != nil {
 				t.Fatal(err)

--- a/adapt_test.go
+++ b/adapt_test.go
@@ -25,7 +25,9 @@ func TestApply(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			adaptedBytes, _, err := Adapter{}.Adapt(b, nil)
+			adaptedBytes, _, err := Adapter{}.Adapt(b, map[string]interface{}{
+				"filename": "test.caddy.yaml",
+			})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/marshal.go
+++ b/marshal.go
@@ -36,7 +36,7 @@ func varsFromBody(b []byte, env []string) (map[string]interface{}, error) {
 		return nil, err
 	}
 
-	varsBytes, err = applyTemplate(varsBytes, nil, env)
+	varsBytes, err = applyTemplate(varsBytes, nil, env, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/marshal.go
+++ b/marshal.go
@@ -27,7 +27,7 @@ func yamlToJSON(b []byte) ([]byte, error) {
 	return json.Marshal(tmp)
 }
 
-func varsFromBody(b []byte) (map[string]interface{}, error) {
+func varsFromBody(b []byte, env []string) (map[string]interface{}, error) {
 	var tmp map[string]interface{}
 	var vars map[string]interface{}
 
@@ -36,7 +36,7 @@ func varsFromBody(b []byte) (map[string]interface{}, error) {
 		return nil, err
 	}
 
-	varsBytes, err = applyTemplate(varsBytes, nil)
+	varsBytes, err = applyTemplate(varsBytes, nil, env)
 	if err != nil {
 		return nil, err
 	}

--- a/template.go
+++ b/template.go
@@ -23,12 +23,12 @@ func applyTemplate(body []byte, values map[string]interface{}, env []string) ([]
 		Delims(openingDelim, closingDelim).
 		Parse(tplBody)
 	if err != nil {
-		return body, err
+		return nil, err
 	}
 
 	var out bytes.Buffer
 	if err := tpl.Execute(&out, values); err != nil {
-		return body, err
+		return nil, err
 	}
 	return out.Bytes(), nil
 }

--- a/template.go
+++ b/template.go
@@ -3,7 +3,6 @@ package caddyyaml
 import (
 	"bytes"
 	"fmt"
-	"strconv"
 	"strings"
 	"text/template"
 
@@ -36,13 +35,7 @@ func applyTemplate(body []byte, values map[string]interface{}, env []string) ([]
 func envVarsTemplate(env []string) string {
 	var builder strings.Builder
 	line := func(key, val string) string {
-		// avoid quoted string
-		if len(val) > 0 && val[0] == '"' {
-			if v, err := strconv.Unquote(val); err == nil {
-				val = v
-			}
-		}
-		return tplWrap(fmt.Sprintf(`$%s := "%s"`, key, val))
+		return tplWrap(fmt.Sprintf(`$%s := %q`, key, val))
 	}
 	for _, env := range env {
 		key, val, _ := strings.Cut(env, "=")

--- a/template.go
+++ b/template.go
@@ -46,8 +46,7 @@ func envVarsTemplate() string {
 		return tplWrap(fmt.Sprintf(`$%s := "%s"`, key, val))
 	}
 	for _, env := range os.Environ() {
-		tmp := strings.SplitN(env, "=", 2)
-		key, val := tmp[0], tmp[1]
+		key, val, _ := strings.Cut(env, "=")
 		fmt.Fprintln(&builder, line(key, val))
 	}
 	return builder.String()

--- a/template.go
+++ b/template.go
@@ -3,7 +3,6 @@ package caddyyaml
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"text/template"
@@ -16,8 +15,8 @@ const (
 	closingDelim = "}"
 )
 
-func applyTemplate(body []byte, values map[string]interface{}) ([]byte, error) {
-	tplBody := envVarsTemplate() + string(body)
+func applyTemplate(body []byte, values map[string]interface{}, env []string) ([]byte, error) {
+	tplBody := envVarsTemplate(env) + string(body)
 
 	tpl, err := template.New("yaml").
 		Funcs(sprig.TxtFuncMap()).
@@ -34,7 +33,7 @@ func applyTemplate(body []byte, values map[string]interface{}) ([]byte, error) {
 	return out.Bytes(), nil
 }
 
-func envVarsTemplate() string {
+func envVarsTemplate(env []string) string {
 	var builder strings.Builder
 	line := func(key, val string) string {
 		// avoid quoted string
@@ -45,7 +44,7 @@ func envVarsTemplate() string {
 		}
 		return tplWrap(fmt.Sprintf(`$%s := "%s"`, key, val))
 	}
-	for _, env := range os.Environ() {
+	for _, env := range env {
 		key, val, _ := strings.Cut(env, "=")
 		fmt.Fprintln(&builder, line(key, val))
 	}

--- a/warnings.go
+++ b/warnings.go
@@ -1,0 +1,22 @@
+package caddyyaml
+
+import "github.com/caddyserver/caddy/v2/caddyconfig"
+
+type warningsCollector struct {
+	filename string
+
+	warnings []caddyconfig.Warning
+}
+
+func (w *warningsCollector) Add(line int, directive string, message string) {
+	w.warnings = append(w.warnings, caddyconfig.Warning{
+		File:      w.filename,
+		Line:      line,
+		Directive: directive,
+		Message:   message,
+	})
+}
+
+func newWarningsCollector(filename string) *warningsCollector {
+	return &warningsCollector{filename, nil}
+}

--- a/yaml.go
+++ b/yaml.go
@@ -11,6 +11,11 @@ func init() {
 // Adapter adapts YAML to Caddy JSON.
 type Adapter struct{}
 
+// envOptionName is the name of the option to set an environment array in the options.
+// This is mainly intended as an internal option to aid in testing, if this is not set then
+// the value of `os.Environ()` is used.
+const envOptionName = "yaml.Env"
+
 // Adapt converts the YAML config in body to Caddy JSON.
 func (a Adapter) Adapt(body []byte, options map[string]interface{}) ([]byte, []caddyconfig.Warning, error) {
 	return adapt(body, options)


### PR DESCRIPTION
The main contribution here is in the last commit: Instead of producing invalid template content and an error that is very misleading (see also #1), it now produces a _warning_ about the problem and skips the variable. The idea here is that not every variable in the environment might be used in the template, and the warning should be visible enough so that whoever is running caddy can fix it if needed.

The second important part https://github.com/abiosoft/caddy-yaml/commit/4cae9528901d12c4de954a3c27281e1a813ff545, which works around problems when environment variables contain `\` characters: A simple `strconv.Unquote` leaves these, and putting the value into quotes then produces problems when processing the template. Solution is to let Sprintf's `%q` format handle the value and quote it properly.

The other commits are cleanups and drive-by improvements.